### PR TITLE
Enhance name field to 30 characters

### DIFF
--- a/sayhello/models.py
+++ b/sayhello/models.py
@@ -13,6 +13,6 @@ from sayhello import db
 
 class Message(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(20))
+    name = db.Column(db.String(30))
     body = db.Column(db.String(200))
     timestamp = db.Column(db.DateTime, default=datetime.utcnow, index=True)


### PR DESCRIPTION
Some of the generated names are longer than the 20 available characters in the field and this leads to failures during the DDEV tests.

E.g. see https://github.com/ddev/ddev/actions/runs/5339277410/jobs/9677778850?pr=5005. Here the name `Christopher Armstrong` with 21 characters was generated.